### PR TITLE
Exit successfully with shutdown-agents

### DIFF
--- a/src/mysqldump_to_redshift/core.clj
+++ b/src/mysqldump_to_redshift/core.clj
@@ -46,4 +46,5 @@
                (flatten)
                (pmap fix-format)
                (stream-lines-out! w))))
-      (println "Infile must not match outfile."))))
+      (println "Infile must not match outfile."))
+    (shutdown-agents)))


### PR DESCRIPTION
Because you used pmap and didn't close it out, the script was hanging. One-liner.